### PR TITLE
Add flags `-u` `-n`, fix the check of output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,7 @@ obs2org/doc/source/_build
 
 # Test output files in ./
 [tT]est*.org
+![tT]est*_orig*.org
 Notes_test/
 test-vault/
 out*.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Obs2Org Changelog
 
+## Version 1.3.0 (2023-03-14)
+
+- Make the error message less cluttered.
+- Add option `-u|--uuid` to add an UUID header to every file that doesn't have one.
+- Add option `-n|--no-cite` to treat `[[@file]]` links as files instead of Pandoc citations.
+
+### Bugfixes
+
+- Fix the check for the output directory that didn't work. If more than one file to convert is given, the output argument must be a directory, not a single file.
+
+### Internal Changes
+
+- Change the format strings to 'f-strings'.
+- Add pylint to `run_local_linters` scripts.
+
 ## Version 1.2.0 (2023-03-13)
 
 - Copy directory structure to the output directory.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Output:
 ```ps1
 > python -m obs2org --help
 
-usage: python -m obs2org [-h] [-V] [-p PANDOC] [-o OUT_PATH] [MARKDOWN_FILES ...]
+usage: python -m obs2org [-h] [-V] [-p PANDOC] [-n] [-u] [-o OUT_PATH] [MARKDOWN_FILES ...]
 
 Converts markdown formatted files to Org-Mode formatted files using Pandoc.
 
@@ -265,6 +265,28 @@ python -m obs2org ./Markdown -o ../Org/ --pandoc c:/pandoc/pandoc
     the same base filename but a `.org` suffix in the directory `../Org`.
     The directory to save to _must_ have a slash `/` at the end.
 
+6. Add UUID file headers to any file that doesn't already have one - flag `-u` or `--uuid`:
+
+    ```ps1
+    python -m obs2org ./Markdown -o ../Org/ -u
+    ```
+
+    Converts all markdown files with a suffix of `.md` in the directory
+    `./Markdown` and its subdirectories to files in Org-Mode format with
+    the same base filename but a `.org` suffix in the directory `../Org`. Add file headers with an UUID if not already present.
+    The directory to save to _must_ have a slash `/` at the end.
+
+7. Treat Pandoc-style citation links as normal links - flag `-n` or `--no-cite`:
+
+    ```ps1
+    python -m obs2org ./Markdown -o ../Org/ -n
+    ```
+
+    Converts all markdown files with a suffix of `.md` in the directory
+    `./Markdown` and its subdirectories to files in Org-Mode format with
+    the same base filename but a `.org` suffix in the directory `../Org`. Treat links like `[[@Name]]` as normal link to a file `@Name.org` instead of Pandoc-style citation `[[cite:@Link]]`.
+    The directory to save to _must_ have a slash `/` at the end.
+
 ### Supported Links
 
 The following list shows which Markdown links are converted to which Org-Mode links:
@@ -274,6 +296,10 @@ The following list shows which Markdown links are converted to which Org-Mode li
 - `[[#heading-id|Caption]]` is changed to `[[#heading-id][Caption]]`
 - `[[file|Caption]]` is changed to `[[file][Caption]]`
 - `[[#Heading]]` is changed to `[[*Heading]]`
+- if `-n` or `--no-cite` is set, a Pandoc citation is treated as a normal link:
+    `[[@Link]]` is changed to `[[file:@Link.org][Link]]`
+- as default Pandoc citation links are converted to citation links:
+    `[[@Link]]` is changed to `[[cite:@Link]]`
 
 ## Development
 

--- a/obs2org/__init__.py
+++ b/obs2org/__init__.py
@@ -9,4 +9,4 @@
 
 from __future__ import annotations
 
-VERSION: str = "1.2.0"
+VERSION: str = "1.3.0"

--- a/obs2org/__main__.py
+++ b/obs2org/__main__.py
@@ -19,8 +19,8 @@ import sys
 
 if sys.version_info.major < 3 or sys.version_info.minor < 9:
     print(
-        "ERROR: Python version is too old, I need at least Python 3.9,"
-        " this has a version of {version}".format(version=platform.python_version()),
+        f"ERROR: Python version is too old, I need at least Python 3.9,"
+        f" this has a version of {platform.python_version()}",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/run_local_linters.bat
+++ b/run_local_linters.bat
@@ -14,5 +14,6 @@ pycodestyle obs2org tests
 pydocstyle obs2org tests
 flake8 obs2org tests
 bandit -r obs2org tests
+pylint --disable=no-member --disable=no-name-in-module obs2org tests
 
-pre-commit run --all-files
+:: pre-commit run --all-files

--- a/run_local_linters.sh
+++ b/run_local_linters.sh
@@ -15,6 +15,7 @@ pycodestyle obs2org tests
 pydocstyle obs2org tests
 flake8 obs2org tests
 bandit -r obs2org tests
+pylint --disable=no-member --disable=no-name-in-module obs2org tests
 
 
-pre-commit run --all-files
+#pre-commit run --all-files

--- a/tests/fixtures/Test 3_orig_no_cite.org
+++ b/tests/fixtures/Test 3_orig_no_cite.org
@@ -8,4 +8,4 @@ Keywords: test, test3
 <2023-03-11>
 Some text.
 
-Cite test: [[cite:@Link]]
+Cite test: [[file:@Link.org][@Link]]

--- a/tests/fixtures/dir1/Test 3.md
+++ b/tests/fixtures/dir1/Test 3.md
@@ -15,3 +15,5 @@ Keywords: test, test3
 2023-03-11
 
 Some text.
+
+Cite test: [[@Link]]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -122,7 +122,7 @@ def test_convert_test1(capsys: pytest.CaptureFixture[str]) -> None:
 
 ################################################################################
 def test_convert_test2(capsys: pytest.CaptureFixture[str]) -> None:
-    """Test conversion of `fixture/dir/test1.md` and `fixture/test2.md`."""
+    """Test conversion of `fixture/dir/test1.md`, `fixture/test2.md` and `dir1/Test 3.md`."""
     run_obs2org(["./tests/fixtures/", "-o=test_out/"])
 
     captured = capsys.readouterr()
@@ -148,6 +148,40 @@ def test_convert_test2(capsys: pytest.CaptureFixture[str]) -> None:
         filecmp.cmp(
             "./test_out/dir1/Test 3.org",
             "./tests/fixtures/Test 3_orig.org",
+            shallow=False,
+        )
+        is True
+    )
+
+
+################################################################################
+def test_convert_test3(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test conversion and removing cites of `fixture/dir/test1.md`, `fixture/test2.md` and `dir1/Test 3.md`."""
+    run_obs2org(["./tests/fixtures/", "-o=test_out/", "-n"])
+
+    captured = capsys.readouterr()
+    assert captured.err == ""  # nosec
+    assert captured.out.find("OK") > 1  # nosec
+    assert (  # nosec
+        filecmp.cmp(
+            "./test_out/dir/test1.org",
+            "./tests/fixtures/test1_orig.org",
+            shallow=False,
+        )
+        is True
+    )
+    assert (  # nosec
+        filecmp.cmp(
+            "./test_out/test2.org",
+            "./tests/fixtures/test2_orig.org",
+            shallow=False,
+        )
+        is True
+    )
+    assert (  # nosec
+        filecmp.cmp(
+            "./test_out/dir1/Test 3.org",
+            "./tests/fixtures/Test 3_orig_no_cite.org",
             shallow=False,
         )
         is True


### PR DESCRIPTION
- Fix the check for the output directory that didn't work. If more than one file to convert is given, the output argument must be a directory, not a single file.
- Make the error message less cluttered.
- Add option `-u|--uuid` to add an UUID header to every file that doesn't have one.
- Add option `-n|--no-cite` to treat `[[@file]]` links as files instead of Pandoc citations.
- Change the format strings to 'f-strings'.
- Add pylint to `run_local_linters` scripts.

See #1